### PR TITLE
Submit all results instead of trying to guess when they're stale.

### DIFF
--- a/KernelInterface.py
+++ b/KernelInterface.py
@@ -201,11 +201,6 @@ class KernelInterface(object):
         # nonce is invalid, it will be caught anyway...
         nonce &= 0xFFFFFFFF
 
-        # Check if the block has changed while this NonceRange was being
-        # processed by the kernel. If so, don't send it to the server.
-        if self.miner.queue.isRangeStale(nr):
-            return False
-
         # Check if the hash meets the full difficulty before sending.
         hash = self.calculateHash(nr, nonce)
 

--- a/WorkQueue.py
+++ b/WorkQueue.py
@@ -70,10 +70,6 @@ class WorkQueue(object):
         # in the future.
         self.staleCallbacks = []
 
-    # Called by foundNonce to check if a NonceRange is stale before submitting
-    def isRangeStale(self, nr):
-        return (nr.unit.identifier != self.block)
-
     def storeWork(self, aw):
 
         #check if this work matches the previous block


### PR DESCRIPTION
Simply forgetting about solutions after a long poll comes in can cause pools to
lose block solutions and miners to lose shares. Not all long polls mean that
all past work is useless - for example, merged mining pools might trigger a
long poll on all of the different chains, but a miner's results might be a
block solution to one of the other unchanged chains.
